### PR TITLE
Minor build fixes and documentation for Apple Silicon/M1

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,106 @@
+# Build QMedia
+
+## MacOS
+These instructions are for MacOS and have been validated on Apple Silicon/M1.
+
+### Dependencies
+1. **xcode** - Install from App Store
+
+   Make sure to validate xcode is installed and the license has been accepted. 
+   ```
+   sudo xcode-select --install
+   sudo xcodebuild -license accept
+   ```
+   Launch **xcode** to make sure there are no other updates or components to install.
+   
+
+   > Not found ```c++``` library error will happen if **xcode** is not correctly install.  
+
+2. **brew** - Follow the instructions at https://brew.sh/
+3. **cmake** - Run ```brew install cmake```
+4. **nasm** - Run ```brew install nasm```
+5. **picotls** - Run the below
+   ```   
+   git clone git@github.com:h2o/picotls.git
+   cd picotls
+   git submodule init
+   git submodule update
+  
+   export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@1.1/lib/pkgconfig"
+   cmake .
+   make
+   ```
+
+6. **picoquic** - Run the below
+   ```
+   git clone git@github.com:private-octopus/picoquic.git
+   cd picoquic
+   
+   export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@1.1/lib/pkgconfig"
+   cmake -B build -S . .
+   cmake --build build
+   ```
+
+7. **quicrq** - Run the below
+   ```
+   git clone git@github.com:Quicr/quicrq.git
+   
+   cd quicrq
+   
+   export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@1.1/lib/pkgconfig"
+   cmake .
+   make
+   ```
+
+
+### Building from Source
+
+#### 1) Clone QMedia Repo
+
+> Below uses SSH, you can clone via other methods
+```
+git clone git@github.com:Quicr/qmedia.git
+```
+
+#### 1) Init Submodules
+Clones/updates the submodules. Currently ```vcpkg``` is the only module. Modules
+are required to run ```cmake```
+
+```
+cd qmedia
+git submodule init
+git submodule update
+```
+
+### 2) Manually build/install vcpkg
+Currently the ```vcpkg``` needs to be build/installed manually.  You can do that by following
+the [vcpkg instructions](https://vcpkg.io/en/getting-started.html). 
+
+For example: 
+
+```
+./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+Downloading vcpkg-macos...
+```
+
+### 2) CMake Init
+Create the build directory as ```build``` using current directory for source files
+
+```
+export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@1.1/lib/pkgconfig"
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug
+```
+
+### 3) CMake Build
+
+
+```
+cmake --build build
+```
+
+## Build Troubleshooting 
+
+In most cases a ```rm -rf build``` in the repo directory will clear problems.
+
+In some cases the dependencies might have changed and introduced new functions/methods/etc.
+Rebuild the dependencies following the above steps to clear those issues up.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ cmake_minimum_required(VERSION 3.10)
 # we have vcpkg installed as a submodule, and this will ensure that we install
 # the dependencies that we need without much knowledge that vcpkg actually
 # exists.
-set(CMAKE_TOOLCHAIN_FILE 
-    ${CMAKE_CURRENT_SOURCE_DIR}/../media/vcpkg/scripts/buildsystems/vcpkg.cmake
+set(CMAKE_TOOLCHAIN_FILE
+    ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake
     CACHE STRING "Vcpkg toolchain file")
 if(NOT EXISTS ${CMAKE_TOOLCHAIN_FILE})
     message(WARNING

--- a/cmake/FindPTLS.cmake
+++ b/cmake/FindPTLS.cmake
@@ -1,32 +1,45 @@
 # - Try to find Picotls
 
 find_path(PTLS_INCLUDE_DIR
-    NAMES picotls/minicrypto.h
-    HINTS ${CMAKE_SOURCE_DIR}/../picotls/include
-          ${CMAKE_BINARY_DIR}/../picotls/include
-          ../picotls/include/ )
+        NAMES picotls/openssl.h
+        HINTS ${PTLS_PREFIX}/include/picotls
+        ${CMAKE_SOURCE_DIR}/../picotls/include
+        ${CMAKE_BINARY_DIR}/../picotls/include
+        ../picotls/include/ )
 
-set(PTLS_HINTS ${CMAKE_BINARY_DIR}/../picotls ../picotls)
+set(PTLS_HINTS ${PTLS_PREFIX}/lib ${CMAKE_BINARY_DIR}/../picotls ../picotls)
 
 find_library(PTLS_CORE_LIBRARY picotls-core HINTS ${PTLS_HINTS})
-find_library(PTLS_MINICRYPTO_LIBRARY picotls-minicrypto HINTS ${PTLS_HINTS})
 find_library(PTLS_OPENSSL_LIBRARY picotls-openssl HINTS ${PTLS_HINTS})
 find_library(PTLS_FUSION_LIBRARY picotls-fusion HINTS ${PTLS_HINTS})
+if(NOT PTLS_FUSION_LIBRARY)
+    include(FindPackageHandleStandardArgs)
+    # handle the QUIETLY and REQUIRED arguments and set PTLS_FOUND to TRUE
+    # if all listed variables are TRUE
+    find_package_handle_standard_args(PTLS REQUIRED_VARS
+            PTLS_CORE_LIBRARY
+            PTLS_OPENSSL_LIBRARY
+            PTLS_INCLUDE_DIR)
+    if(PTLS_FOUND)
+        set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_OPENSSL_LIBRARY} )
+        set(PTLS_INCLUDE_DIRS ${PTLS_INCLUDE_DIR})
+        set(PTLS_WITH_FUSION_DEFAULT OFF)
+    endif()
+else()
+    include(FindPackageHandleStandardArgs)
+    # handle the QUIETLY and REQUIRED arguments and set PTLS_FOUND to TRUE
+    # if all listed variables are TRUE
+    find_package_handle_standard_args(PTLS REQUIRED_VARS
+            PTLS_CORE_LIBRARY
+            PTLS_OPENSSL_LIBRARY
+            PTLS_FUSION_LIBRARY
+            PTLS_INCLUDE_DIR)
 
-include(FindPackageHandleStandardArgs)
-# handle the QUIETLY and REQUIRED arguments and set PTLS_FOUND to TRUE
-# if all listed variables are TRUE
-find_package_handle_standard_args(PTLS REQUIRED_VARS
-    PTLS_CORE_LIBRARY
-    PTLS_MINICRYPTO_LIBRARY
-    PTLS_OPENSSL_LIBRARY
-    PTLS_FUSION_LIBRARY
-    PTLS_INCLUDE_DIR)
-
-if(PTLS_FOUND)
-    set(PTLS_LIBRARIES
-        ${PTLS_CORE_LIBRARY} ${PTLS_MINICRYPTO_LIBRARY} ${PTLS_OPENSSL_LIBRARY} ${PTLS_FUSION_LIBRARY})
-    set(PTLS_INCLUDE_DIRS ${PTLS_INCLUDE_DIR})
+    if(PTLS_FOUND)
+        set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_OPENSSL_LIBRARY} ${PTLS_FUSION_LIBRARY})
+        set(PTLS_INCLUDE_DIRS ${PTLS_INCLUDE_DIR})
+        set(PTLS_WITH_FUSION_DEFAULT ON)
+    endif()
 endif()
 
 mark_as_advanced(PTLS_LIBRARIES PTLS_INCLUDE_DIRS)

--- a/src/h264_decoder.cc
+++ b/src/h264_decoder.cc
@@ -65,7 +65,7 @@ int H264Decoder::decode(const char *input_buffer,
     unsigned char *dst[3];
     SBufferInfo dst_info;
 
-    auto ret = decoder->DecoderFame2(
+    auto ret = decoder->DecodeFrame2(
         reinterpret_cast<const unsigned char *>(input_buffer),
         input_length,
         dst,

--- a/src/netTransportQuicR.cc
+++ b/src/netTransportQuicR.cc
@@ -152,6 +152,7 @@ static int media_frame_publisher_fn(quicrq_media_source_action_enum action,
                                     size_t *data_length,
                                     int *is_last_segment,
                                     int *is_media_finished,
+                                    int *is_still_active,
                                     uint64_t current_time)
 {
     int ret = 0;

--- a/src/netTransportQuicR.cc
+++ b/src/netTransportQuicR.cc
@@ -152,7 +152,6 @@ static int media_frame_publisher_fn(quicrq_media_source_action_enum action,
                                     size_t *data_length,
                                     int *is_last_segment,
                                     int *is_media_finished,
-                                    int *is_still_active,
                                     uint64_t current_time)
 {
     int ret = 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,4 +14,4 @@ target_compile_definitions(${PROJECT_NAME} INTERFACE -DDATA_PATH="${CMAKE_CURREN
 # Enable CTest
 include(doctest)
 enable_testing()
-doctest_discover_tests(${TEST_APP_NAME})
+doctest_discover_tests(${TEST_APP_NAME} ADD_LABELS 0)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,6 @@
     "opus",
     "openssl",
     "doctest",
-    "dav1d",
     "libsamplerate",
     "curl",
     "openh264",


### PR DESCRIPTION
* Adds BUILD.md to document various builds.
  Currently Apple/MacOS is documented.
* Updates FindPTLS.cmake to latest from
  picotls. Fixes #9
* Removes dav1d from vcpkg. Fixes #10
* Fix typo in decoder->DecodeFrame2
* Update publisher callback to include
  ```is_still_active``` param.
* Fix minor issue with cmake toolchain looking for
  ```media``` directory.  Fixes #12
* Fixes issue with **doctest** requiring ```TEST_ADD_LABELS```
  This can be reverted once vcpkg is updated to use latest
  doctest.  See https://github.com/doctest/doctest/commit/60de2232ac45f0002bb138bc80c4a69c7b2cf874 for more details on
  fix.