### PR TITLE
Changes to bring in OpenH264 via vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,9 @@ if (APPLE)
 
   message(STATUS "openh64: ${OpenH264_LIB_DIR}")
   message(STATUS "openh64-inc ${OpenH264_INCLUDE_DIR}")
+else()
+    find_library(openh264 openh264 REQUIRED)
+    message(STATUS "Found OpenH264: ${openh264}")
 endif()
 
 ###

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(qmedia
     PUBLIC
         ${LIBRARIES}
         OpenSSL::Crypto
-        openh264
+        ${openh264}
         quicr)
 target_include_directories(qmedia
     PUBLIC

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,6 +5,7 @@
     "protobuf",
     "opus",
     "openssl",
+    "openh264",
     "doctest",
     "libsamplerate",
     "curl",


### PR DESCRIPTION
Brings in OpenH264 via vcpkg, removing the need to have that preinstalled on the machine.